### PR TITLE
Fixed link to downloads section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 This is Red Pill, a 3D OpenGL "Matrix" screensaver for Mac OS X.
 Copyright © 2002-2012 mathew <meta@pobox.com>.
 
-Looking for a binary download? Check [the downloads section](/lpar/RedPill/downloads).
+Looking for a binary download? Check [the downloads section](https://github.com/lpar/RedPill/downloads).
 
 Red Pill is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
The previous version of this link is interpreted relative to README.md access and does not stand alone if the source is downloaded. Changing this to an absolute link and pointing to the right location (instead of resulting in a Github 404 URI) will help users get the binary files they desire.
